### PR TITLE
Support adding service_id and service_name tags when they use auto-generated values

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .idea
 solace/aws.yaml
+pubsubplus/self-managed-insights-values.yaml

--- a/pubsubplus/templates/insights-configmap-agent.yaml
+++ b/pubsubplus/templates/insights-configmap-agent.yaml
@@ -6,7 +6,7 @@
 {{- $serviceId := "" -}}
 {{- $serviceName := "" -}}
 
-{{- $existingConfig := (lookup "v1" "ConfigMap" .Release.Namespace (printf "%s-service-info-tags" (include "solace.fullname" .))) -}}
+{{- $existingConfig := (lookup "v1" "ConfigMap" .Release.Namespace (printf "%s-monitoring-insights-service-info-tags" (include "solace.fullname" .))) -}}
 
 {{- if $existingConfig -}}
     {{- $serviceId = index $existingConfig.data "service_id" -}}
@@ -25,15 +25,19 @@
       {{- if not $serviceId -}}
         {{- $serviceId = $value -}}
         {{- $includeServiceIdTag = false -}}
+        {{- $ddTagsCustomerProvided = printf "%s%s%s:%s" $ddTagsCustomerProvided (ternary "" " " (eq $ddTagsCustomerProvided "")) $key $value -}}
       {{- end -}}
     {{- end -}}
     {{- if eq $key "service_name" -}}
       {{- if not $serviceName -}}
         {{- $serviceName = $value -}}
         {{- $includeServiceNameTag = false -}}
+        {{- $ddTagsCustomerProvided = printf "%s%s%s:%s" $ddTagsCustomerProvided (ternary "" " " (eq $ddTagsCustomerProvided "")) $key $value -}}
       {{- end -}}
     {{- end -}}
-    {{- $ddTagsCustomerProvided = printf "%s%s%s:%s" $ddTagsCustomerProvided (ternary "" " " (eq $ddTagsCustomerProvided "")) $key $value -}}
+    {{- if and (ne $key "service_id") (ne $key "service_name") -}}
+      {{- $ddTagsCustomerProvided = printf "%s%s%s:%s" $ddTagsCustomerProvided (ternary "" " " (eq $ddTagsCustomerProvided "")) $key $value -}}
+    {{- end -}}
   {{- end -}}
 {{- end -}}
 
@@ -70,7 +74,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ template "solace.fullname" . }}-service-info-tags
+  name: {{ template "solace.fullname" . }}-monitoring-insights-service-info-tags
 data:
   service_id: "{{ $serviceId }}"
   service_name: "{{ $serviceName }}"

--- a/pubsubplus/templates/insights-configmap-agent.yaml
+++ b/pubsubplus/templates/insights-configmap-agent.yaml
@@ -6,6 +6,13 @@
 {{- $serviceId := "" -}}
 {{- $serviceName := "" -}}
 
+{{- $existingConfig := (lookup "v1" "ConfigMap" .Release.Namespace (printf "%s-service-ids" (include "solace.fullname" .))) -}}
+
+{{- if $existingConfig -}}
+    {{- $serviceId = index $existingConfig.data "service_id" -}}
+    {{- $serviceName = index $existingConfig.data "service_name" -}}
+{{- end -}}
+
 {{- $includeServiceIdTag := true -}}
 {{- $includeServiceNameTag := true -}}
 
@@ -15,12 +22,16 @@
       {{- $orgId = $value -}}
     {{- end -}}
     {{- if eq $key "service_id" -}}
-      {{- $serviceId = $value -}}
-      {{- $includeServiceIdTag = false -}}
+      {{- if not $serviceId -}}
+        {{- $serviceId = $value -}}
+        {{- $includeServiceIdTag = false -}}
+      {{- end -}}
     {{- end -}}
     {{- if eq $key "service_name" -}}
-      {{- $serviceName = $value -}}
-      {{- $includeServiceNameTag = false -}}
+      {{- if not $serviceName -}}
+        {{- $serviceName = $value -}}
+        {{- $includeServiceNameTag = false -}}
+      {{- end -}}
     {{- end -}}
     {{- $ddTagsCustomerProvided = printf "%s%s%s:%s" $ddTagsCustomerProvided (ternary "" " " (eq $ddTagsCustomerProvided "")) $key $value -}}
   {{- end -}}
@@ -30,10 +41,10 @@
   {{- fail "Organization ID not specified" -}}
 {{- end -}}
 
-{{- if eq $serviceId "" -}}
+{{- if not $serviceId -}}
   {{- $serviceId = (randAlpha 6) -}}
 {{- end -}}
-{{- if eq $serviceName "" -}}
+{{- if $serviceName -}}
   {{- $serviceName = printf "service_%s" $serviceId -}}
 {{- end -}}
 
@@ -59,8 +70,16 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
+  name: {{ template "solace.fullname" . }}-service-info-tags
+data:
+  service_id: "{{ $serviceId }}"
+  service_name: "{{ $serviceName }}"
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
   name: {{ template "solace.fullname" . }}-monitoring-insights-env-configs
 data:
-  DD_SITE: {{ .Values.insights.datadogSite }}
-  DD_TAGS: {{ $ddTags }}
+  DD_SITE: "{{ .Values.insights.datadogSite }}"
+  DD_TAGS: "{{ $ddTags }}"
   {{- end }}

--- a/pubsubplus/templates/insights-configmap-agent.yaml
+++ b/pubsubplus/templates/insights-configmap-agent.yaml
@@ -49,8 +49,8 @@
     $maasDatacenterId
     .Values.solace.size
     $serviceType
-    (ternary (printf " service_id:%s" $serviceId) "" (not $includeServiceIdTag))
-    (ternary (printf " service_name:%s" $serviceName) "" (not $includeServiceNameTag))
+    (ternary (printf " service_id:%s" $serviceId) "" ($includeServiceIdTag))
+    (ternary (printf " service_name:%s" $serviceName) "" ($includeServiceNameTag))
 -}}
 {{- $ddTagsDefault := "monitoring_mode:advanced datacenter_access_type:Private datacenter_type:CustomerManaged is_trial:false peb_type:software provider:k8s maas_id:customermanaged" -}}
 

--- a/pubsubplus/templates/insights-configmap-agent.yaml
+++ b/pubsubplus/templates/insights-configmap-agent.yaml
@@ -6,6 +6,9 @@
 {{- $serviceId := "" -}}
 {{- $serviceName := "" -}}
 
+{{- $includeServiceIdTag := true -}}
+{{- $includeServiceNameTag := true -}}
+
 {{- range $index, $tag := $tagsArray -}}
   {{- range $key, $value := $tag -}}
     {{- if eq $key "org_id" -}}
@@ -13,9 +16,11 @@
     {{- end -}}
     {{- if eq $key "service_id" -}}
       {{- $serviceId = $value -}}
+      {{- $includeServiceIdTag = false -}}
     {{- end -}}
     {{- if eq $key "service_name" -}}
       {{- $serviceName = $value -}}
+      {{- $includeServiceNameTag = false -}}
     {{- end -}}
     {{- $ddTagsCustomerProvided = printf "%s%s%s:%s" $ddTagsCustomerProvided (ternary "" " " (eq $ddTagsCustomerProvided "")) $key $value -}}
   {{- end -}}
@@ -38,7 +43,15 @@
 
 {{- $serviceType := include "solace.serviceType" . -}}
 
-{{- $ddTagsCalculated := printf "infrastructure_name:%s-%s maas_datacenter_id:%s service_class:%s service_type:%s" (include "solace.fullname" .) $serviceId $maasDatacenterId .Values.solace.size $serviceType -}}
+{{- $ddTagsCalculated := printf "infrastructure_name:%s-%s maas_datacenter_id:%s service_class:%s service_type:%s%s%s"
+    (include "solace.fullname" .)
+    $serviceId
+    $maasDatacenterId
+    .Values.solace.size
+    $serviceType
+    (ternary (printf " service_id:%s" $serviceId) "" (not $includeServiceIdTag))
+    (ternary (printf " service_name:%s" $serviceName) "" (not $includeServiceNameTag))
+-}}
 {{- $ddTagsDefault := "monitoring_mode:advanced datacenter_access_type:Private datacenter_type:CustomerManaged is_trial:false peb_type:software provider:k8s maas_id:customermanaged" -}}
 
 {{- $ddTags := printf "%s %s %s" $ddTagsDefault $ddTagsCalculated $ddTagsCustomerProvided -}}

--- a/pubsubplus/templates/insights-configmap-agent.yaml
+++ b/pubsubplus/templates/insights-configmap-agent.yaml
@@ -6,7 +6,7 @@
 {{- $serviceId := "" -}}
 {{- $serviceName := "" -}}
 
-{{- $existingConfig := (lookup "v1" "ConfigMap" .Release.Namespace (printf "%s-service-ids" (include "solace.fullname" .))) -}}
+{{- $existingConfig := (lookup "v1" "ConfigMap" .Release.Namespace (printf "%s-service-info-tags" (include "solace.fullname" .))) -}}
 
 {{- if $existingConfig -}}
     {{- $serviceId = index $existingConfig.data "service_id" -}}

--- a/pubsubplus/templates/insights-configmap-agent.yaml
+++ b/pubsubplus/templates/insights-configmap-agent.yaml
@@ -44,7 +44,7 @@
 {{- if not $serviceId -}}
   {{- $serviceId = (randAlpha 6) -}}
 {{- end -}}
-{{- if $serviceName -}}
+{{- if not $serviceName -}}
   {{- $serviceName = printf "service_%s" $serviceId -}}
 {{- end -}}
 


### PR DESCRIPTION
Currently, the Insights configuration template will correctly compute a service ID and service name value if they aren't provided in the Helm values for the insights tags. However, if they're not provided, they don't end up getting added to the DD tags. This changes addresses that by ensuring that either the `service_id` or `service_name` tags are added to the agent's tags should they not be provided in the Helm values. It also uses an additional ConfigMap to persist the values of `service_id` and `service_name` after an initial installation, so that they are not auto-generated or overridden on upgrades.

Tested with Helm template.

---
Supplemental `values.yaml` without `service_id` and without `service_name`:

```yaml
insights:
  enabled: true
  datadogAPIKey: myapikey

  environment_name: prod

  tags:
    - org_id: mysolaceorg
    - datacenter_id: my-dc-us-east-1
```

DD_TAGS:
```
monitoring_mode:advanced datacenter_access_type:Private datacenter_type:CustomerManaged is_trial:false peb_type:software provider:k8s maas_id:customermanaged infrastructure_name:release-name-pubsubplus-qQPOsb maas_datacenter_id:mysolaceorg_prod service_class:prod100 service_type:enterprise-standalone service_id:qQPOsb service_name:service_qQPOsb org_id:mysolaceorg datacenter_id:my-dc-us-east-1
```
As can be seen both `service_id` and `service_name` are the randomly/autogenerated values.

---
Supplemental `values.yaml` without `service_id` but with `service_name`:

```yaml
insights:
  enabled: true
  datadogAPIKey: myapikey

  environment_name: prod

  tags:
    - service_name: myservice
    - org_id: mysolaceorg
    - datacenter_id: my-dc-us-east-1
```

DD_TAGS:
```
monitoring_mode:advanced datacenter_access_type:Private datacenter_type:CustomerManaged is_trial:false peb_type:software provider:k8s maas_id:customermanaged infrastructure_name:release-name-pubsubplus-AToRtB maas_datacenter_id:mysolaceorg_prod service_class:prod100 service_type:enterprise-standalone service_id:AToRtB service_name:myservice org_id:mysolaceorg datacenter_id:my-dc-us-east-1
```
As can be seen `service_id` is the randomly generated value and `service_name` is the configured name from the Helm values.

---
Supplemental `values.yaml` with `service_id` but without `service_name`:

```yaml
insights:
  enabled: true
  datadogAPIKey: myapikey

  environment_name: prod

  tags:
    - service_id: myserviceid
    - org_id: mysolaceorg
    - datacenter_id: my-dc-us-east-1
```

DD_TAGS:
```
monitoring_mode:advanced datacenter_access_type:Private datacenter_type:CustomerManaged is_trial:false peb_type:software provider:k8s maas_id:customermanaged infrastructure_name:release-name-pubsubplus-myserviceid maas_datacenter_id:mysolaceorg_prod service_class:prod100 service_type:enterprise-standalone service_name:service_myserviceid service_id:myserviceid org_id:mysolaceorg datacenter_id:my-dc-us-east-1
```
As can be seen `service_id` is the configured ID from the Helm values and `service_name` is the autogenerated value.

---
Supplemental `values.yaml` with `service_id` and with `service_name` defined:

```yaml
insights:
  enabled: true
  datadogAPIKey: myapikey

  environment_name: prod

  tags:
    - service_id: myserviceid
    - service_name: myservice
    - org_id: mysolaceorg
    - datacenter_id: my-dc-us-east-1
```

DD_TAGS:
```
monitoring_mode:advanced datacenter_access_type:Private datacenter_type:CustomerManaged is_trial:false peb_type:software provider:k8s maas_id:customermanaged infrastructure_name:release-name-pubsubplus-myserviceid maas_datacenter_id:mysolaceorg_prod service_class:prod100 service_type:enterprise-standalone service_id:myserviceid service_name:myservice org_id:mysolaceorg datacenter_id:my-dc-us-east-1
```
As can be seen both `service_id` and `service_name` are the values provided in the Helm values.