### PR TITLE
DATAGO-96500: Update Helm command references

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ A gray check mark shows the broker deployment using helm chart is supported but 
 |-------------------------|--------------------------------------------------|-----------|
 | Google Kubernetes Engine (GKE)                       | 10.4.1                                           | ![image](https://github.com/user-attachments/assets/f22255d5-ec7e-4f6e-a0c9-ac75c3992016)        |
 | Amazon Elastic Kubernetes Service (EKS)                       | 10.4.1                                           | ![image](https://github.com/user-attachments/assets/df403828-04a8-4ca5-9b6c-303b270640e8)         |
-| Azure Kubernetes Service (AKS)                      | 10.4.1                                           | ![image](https://github.com/user-attachments/assets/df403828-04a8-4ca5-9b6c-303b270640e8)         |
+| Azure Kubernetes Service (AKS)                      | 10.4.1                                           | ![image](https://github.com/user-attachments/assets/bfefe455-d6d8-49a4-98d0-dee8d791dc66)         |
 |                         |                                                  |           |
 
 ## Versioning

--- a/docs/PubSubPlusK8SDeployment.md
+++ b/docs/PubSubPlusK8SDeployment.md
@@ -140,7 +140,8 @@ This option overrides simplified vertical scaling. It enables specifying each su
 
 Additionally, CPU and memory must be sized and provided in `solace.systemScaling.cpu` and `solace.systemScaling.memory` parameters. Use the [Solace online System Resource Calculator](https://docs.solace.com/Configuring-and-Managing/SW-Broker-Specific-Config/System-Resource-Calculator.htm) to determine CPU and memory requirements for the selected scaling parameters.
 
-Note: beyond CPU and memory requirements, required storage size (see next section) also depends significantly on scaling. The calculator can be used to determine that as well.
+> Note: beyond CPU and memory requirements, required storage size (see next section) also depends significantly on scaling. We recommend using the minimum required values specified in the [Resource Calculator](https://docs.solace.com/Configuring-and-Managing/SW-Broker-Specific-Config/System-Resource-Calculator.htm).
+> However, you can adjust these values in the YAML file based on your available resources. If you decide to allocate fewer resources than the recommended minimum, make sure to thoroughly test your deployment to ensure stability and performance.
 
 Also note, that specifying maxConnections, maxQueueMessages and maxSpoolUsage on initial deployment will overwrite the broker’s default values. On the other hand, doing the same using Helm upgrade on an existing deployment will not overwrite these values on brokers configuration, but it can be used to prepare (first step) for a manual scale up through CLI where these parameters can be actually changed (second step).
 

--- a/docs/helm-charts/test-chart-variants-from-gh-pages.sh
+++ b/docs/helm-charts/test-chart-variants-from-gh-pages.sh
@@ -13,7 +13,7 @@ kubectl get nodes -o wide
 testDeployHelmv2 () {
   # Params: $1 is the Helm chart name
   echo
-  helm install --name my-release solacecharts/$1 --set solace.size=dev
+  helm install my-release solacecharts/$1 --set solace.size=dev
   echo
   echo "Waiting for chart $1 to deploy..."
   echo

--- a/docs/helm-charts/test-chart-variants-from-gh-pages.sh
+++ b/docs/helm-charts/test-chart-variants-from-gh-pages.sh
@@ -13,7 +13,7 @@ kubectl get nodes -o wide
 testDeployHelmv2 () {
   # Params: $1 is the Helm chart name
   echo
-  helm install my-release solacecharts/$1 --set solace.size=dev
+  helm install --name my-release solacecharts/$1 --set solace.size=dev
   echo
   echo "Waiting for chart $1 to deploy..."
   echo

--- a/pubsubplus/README.md
+++ b/pubsubplus/README.md
@@ -70,7 +70,7 @@ solace:
   redundancy: true
   usernameAdminPassword: secretpassword" > my-values.yaml
 # Now use the file:
-helm install --name my-release -f my-values.yaml solacecharts/pubsubplus
+helm install my-release -f my-values.yaml solacecharts/pubsubplus
 ```
 > Note: as an alternative to creating a new file you can [download](https://raw.githubusercontent.com/SolaceProducts/pubsubplus-kubernetes-helm-quickstart/master/pubsubplus/values.yaml) the `values.yaml` file with default values and edit that for overrides.
 

--- a/pubsubplus/templates/solaceStatefulSet.yaml
+++ b/pubsubplus/templates/solaceStatefulSet.yaml
@@ -68,7 +68,7 @@ spec:
             cpu: "1"
             memory: 3410Mi
 {{- else if eq .Values.solace.size "prod1k" }}
-            cpu: "1.5"
+            cpu: "2"
             memory: 6515Mi
 {{- else if eq .Values.solace.size "prod10k" }}
             cpu: "4"
@@ -90,7 +90,7 @@ spec:
             cpu: "2"
             memory: 3410Mi
 {{- else if eq .Values.solace.size "prod1k" }}
-            cpu: "1.5"
+            cpu: "2"
             memory: 6515Mi
 {{- else if eq .Values.solace.size "prod10k" }}
             cpu: "4"


### PR DESCRIPTION
As per [DATAGO-96500](https://sol-jira.atlassian.net/browse/DATAGO-96500), the Helm QuickStart is updated to address documentation-related inconsistencies as observed during our test blitz for the self-managed Insights feature.

Some changes came from the `master` branch not related to the actual change; the actual changes are specifically highlighted. They relate only to helm commands using the older Helm V2 syntax.

[DATAGO-96500]: https://sol-jira.atlassian.net/browse/DATAGO-96500?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ